### PR TITLE
add Pillow python package to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.8-buster
-RUN mkdir /data && apt-get update -q && apt-get install -y rrdtool && pip3 install requests speedtest-cli python-dateutil && fc-cache && apt-get clean
+RUN mkdir /data && apt-get update -q && apt-get install -y rrdtool && pip3 install requests speedtest-cli python-dateutil Pillow && fc-cache && apt-get clean
 COPY measure.py /measure.py
 CMD python3 ./measure.py


### PR DESCRIPTION
In the initial python 3.8 buster container Pillow was not installed, but you require `import PIL from Image`. So I added the dependency in the Dockerfile